### PR TITLE
Support for other classification criterion for inner trees.

### DIFF
--- a/dpdt/boosted_dpdt.py
+++ b/dpdt/boosted_dpdt.py
@@ -869,6 +869,7 @@ class AdaBoostDPDT(AdaBoostClassifier):
         n_estimators=50,
         learning_rate=1,
         time_limit=None,
+        criterion = 'gini',
     ):
         super().__init__(
             estimator=DPDTreeClassifier(
@@ -882,6 +883,7 @@ class AdaBoostDPDT(AdaBoostClassifier):
                 max_features=max_features,
                 random_state=random_state,
                 n_jobs=n_jobs,
+                criterion=criterion,
             ),
             n_estimators=n_estimators,
             learning_rate=learning_rate,

--- a/dpdt/dpdt_classifier.py
+++ b/dpdt/dpdt_classifier.py
@@ -206,6 +206,8 @@ class DPDTreeClassifier(ClassifierMixin, BaseEstimator):
         ],
         "random_state": ["random_state"],
         "min_impurity_decrease": [Interval(Real, 0.0, None, closed="left")],
+        "criterion": [
+            StrOptions({"gini", "entropy", "log_loss"})],
         "n_jobs": [
             Interval(Integral, 1, None, closed="left"),
             None,
@@ -228,6 +230,7 @@ class DPDTreeClassifier(ClassifierMixin, BaseEstimator):
         min_weight_fraction_leaf=0.0,
         max_features=None,
         min_impurity_decrease=0.0,
+        criterion="gini",
     ):
         """Initialize the DPDTreeClassifier."""
         self.max_depth = max_depth
@@ -240,6 +243,7 @@ class DPDTreeClassifier(ClassifierMixin, BaseEstimator):
         self.min_weight_fraction_leaf = min_weight_fraction_leaf
         self.max_features = max_features
         self.min_impurity_decrease = min_impurity_decrease
+        self.criterion = criterion
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y, sample_weight=None):
@@ -439,6 +443,7 @@ class DPDTreeClassifier(ClassifierMixin, BaseEstimator):
                     min_samples_leaf=self.min_samples_leaf,
                     min_weight_fraction_leaf=self.min_weight_fraction_leaf,
                     max_features=self.max_features,
+                    criterion=self.criterion,
                 )
             else:
                 clf = DecisionTreeClassifier(
@@ -449,6 +454,7 @@ class DPDTreeClassifier(ClassifierMixin, BaseEstimator):
                     min_samples_leaf=self.min_samples_leaf,
                     min_weight_fraction_leaf=self.min_weight_fraction_leaf,
                     max_features=self.max_features,
+                    criterion=self.criterion,
                 )
             clf.fit(self.X_[node.nz], self.y_[node.nz], self._sample_weight[node.nz])
 


### PR DESCRIPTION
Current implementation of the DPDTClassifier only allows searching for splits via `gini`. Added the ability to pass `criterion` as a hyperparameter. 